### PR TITLE
cdo gather/collgrid fix

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,6 +22,7 @@ jobs:
         python-version: [3.8]
         cdo-version: [null, 1.7.0, 2.0.0]
 
+    name: python ${{ matrix.python-version }} with cdo ${{ matrix.cdo-version }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,8 +22,15 @@ jobs:
         python-version: [3.8]
         cdo-version: [null, 1.9.6, 2.0.0]
 
-    name: python ${{ matrix.python-version }} ${{ matrix.cdo-version != null && "with cdo " + matrix.cdo-version || "without cdo" }}
+    name: python ${{ matrix.python-version }} ${{ matrix.cdo-version != null && "with cdo" || "without cdo" }} ${{ matrix.cdo-version }}
     steps:
+      - uses: haya14busa/action-cond@v1
+        id: nameval
+        with:
+          cond: ${{ matrix.cdo-version != null }}
+          if_true: with cdo ${{ matrix.cdo-version }}
+          if_false: without cdo
+
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
       - uses: conda-incubator/setup-miniconda@v2
+        if: matrix.cdo-version != null
         with:
           channels: conda-forge
           channel-priority: strict
@@ -43,10 +44,16 @@ jobs:
           auto-update-conda: false
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up conda environment
+      - name: Install cdo
         if: matrix.cdo-version != null
         run: |
           mamba install cdo==${{ matrix.cdo-version }} -c conda-forge
+
+      - name: Set up Python ${{ matrix.python-version }}
+        if: matrix.cdo-version == null
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: [3.8]
         cdo-version: [null, 1.9.6, 2.0.0]
 
-    name: python ${{ matrix.python-version }} ${{ matrix.cdo-version != null && "with" || "without" }} cdo ${{ matrix.cdo-version }}
+    name: python ${{ matrix.python-version }} ${{ matrix.cdo-version != null && 'with' || 'without' }} cdo ${{ matrix.cdo-version }}
     steps:
       - uses: haya14busa/action-cond@v1
         id: nameval

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
-        cdo-version: [null, 1.7.0, 2.0.0]
+        cdo-version: [null, 1.9.6, 2.0.0]
 
-    name: python ${{ matrix.python-version }} with cdo ${{ matrix.cdo-version }}
+    name: python ${{ matrix.python-version }} ${{ matrix.cdo-version != null && "with cdo " + matrix.cdo-version || "without cdo" }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: [3.8]
         cdo-version: [null, 1.9.6, 2.0.0]
 
-    name: python ${{ matrix.python-version }} ${{ matrix.cdo-version != null && "with cdo" || "without cdo" }} ${{ matrix.cdo-version }}
+    name: python ${{ matrix.python-version }} ${{ matrix.cdo-version != null && "with" || "without" }} cdo ${{ matrix.cdo-version }}
     steps:
       - uses: haya14busa/action-cond@v1
         id: nameval

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     defaults:
+      # for micromamba
       run:
         shell: bash -l {0}
 
@@ -19,19 +20,30 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
+        cdo-version: [null, 1.7.0, 2.0.0]
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Fetch all history for all branches and tags.
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          channels: conda-forge
+          channel-priority: strict
+          mamba-version: "*"
+          activate-environment: convml_tt
+          auto-update-conda: false
+          python-version: ${{ matrix.python-version }}
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up conda environment
+        if: matrix.cdo-version != null
+        run: |
+          mamba install cdo==${{ matrix.cdo-version }} -c conda-forge
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install ".[test]"
-    - name: Test package with pytest
-      run: |
-        python -m pytest
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[test]"
+      - name: Test package with pytest
+        run: |
+          CDO_VERSION=${{ matrix.cdo-version }} python -m pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@
 
 [Full Changelog](https://github.com/convml/convml_tt/compare/...v0.1.1)
 
+*new features*
+
+- Add support cdo version `>= 1.7.0`. In cdo `1.7.0` the `gather` command was
+  renamed as `collgrid`, the extraction routines now check for which command is
+  available. Continous integration now checks multiple cdo version and without
+  cdo for extraction (using only xarray)
+  [\#7](https://github.com/leifdenby/uclales-utils/pull/7)
+
 *bugfixes*
+
+- Fix to ensure that extacting using y-strips works with cdo.
+  [\#7](https://github.com/leifdenby/uclales-utils/pull/7)
 
 - Fix numerous bugs, specifically: 1) ensure `use_cdo` is correctly passed to
   child-tasks. 2) 3D source-files don't have a timestep (`tn`) in the filename,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@
 
 - Add support cdo version `>= 1.7.0`. In cdo `1.7.0` the `gather` command was
   renamed as `collgrid`, the extraction routines now check for which command is
-  available. Continous integration now checks multiple cdo version and without
+  available. Continuous integration now checks multiple cdo version and without
   cdo for extraction (using only xarray)
   [\#7](https://github.com/leifdenby/uclales-utils/pull/7)
 
 *bugfixes*
 
-- Fix to ensure that extacting using y-strips works with cdo.
+- Fix to ensure that extracting using y-strips works with cdo.
   [\#7](https://github.com/leifdenby/uclales-utils/pull/7)
 
 - Fix numerous bugs, specifically: 1) ensure `use_cdo` is correctly passed to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,26 @@
 # Changelog
 
 
+## [Unreleased](https://github.com/leifdenby/uclales-utils/tree/HEAD)
+
+[Full Changelog](https://github.com/convml/convml_tt/compare/...v0.1.1)
+
+*bugfixes*
+
+- Fix numerous bugs, specifically: 1) ensure `use_cdo` is correctly passed to
+  child-tasks. 2) 3D source-files don't have a timestep (`tn`) in the filename,
+  3) fix concatenation when all extraction is done with xarray, 4) ensure all
+  possible methods of extraction (`blocks`, `x_strips` and `y_strips`) are all
+  tested [\#8](https://github.com/leifdenby/uclales-utils/pull/8)
+
+
 ## [v0.1.1](https://github.com/leifdenby/uclales-utils/tree/v0.1.1) (2022-01-31)
 
 [Full Changelog](https://github.com/convml/convml_tt/compare/v0.1.1...v0.1.0)
 
 *maintance*
 
-Update instructions in the README [\#6](https://github.com/leifdenby/uclales-utils/pull/6)
+- Update instructions in the README [\#6](https://github.com/leifdenby/uclales-utils/pull/6)
 
 
 ## [v0.1.0](https://github.com/leifdenby/uclales-utils/tree/v0.1.0) (2022-01-31)

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -7,7 +7,7 @@ import pytest
 
 import uclales
 
-USE_CDO = os.environ.get("CDO_VERSION", "null") != "null"
+USE_CDO = os.environ.get("CDO_VERSION", "") != ""
 EXTRACTION_MODES = ["blocks", "x_strips", "y_strips"]
 
 

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,21 +1,50 @@
+import tempfile
+from pathlib import Path
+
 import luigi
+import pytest
 
 import uclales
 
+USE_CDO = False
+EXTRACTION_MODES = ["blocks", "x_strips", "y_strips"]
 
-def test_extract_3d(testdata_path):
+
+@pytest.mark.parametrize("extraction_mode", EXTRACTION_MODES)
+def test_extract_3d(testdata_path, extraction_mode):
+    if extraction_mode == "blocks" and USE_CDO:
+        # skip this test since we can't currently extract-by-blocks with cdo
+        # and so the extraction will fail
+        return True
+
+    tmpdir = tempfile.TemporaryDirectory()
+    output_path = Path(tmpdir.name)
+
     task = uclales.output.Extract(
         var_name="w",
         tn=0,
         kind="3d",
         file_prefix="rico",
         source_path=testdata_path,
+        use_cdo=USE_CDO,
+        mode=extraction_mode,
+        dest_path=output_path,
     )
 
     luigi.build([task], local_scheduler=True)
+    assert task.output().exists()
 
 
-def test_extract_2d(testdata_path):
+@pytest.mark.parametrize("extraction_mode", EXTRACTION_MODES)
+def test_extract_2d(testdata_path, extraction_mode):
+    if extraction_mode == "blocks" and USE_CDO:
+        # skip this test since we can't currently extract-by-blocks with cdo
+        # and so the extraction will fail
+        return True
+
+    tmpdir = tempfile.TemporaryDirectory()
+    output_path = Path(tmpdir.name)
+
     task = uclales.output.Extract(
         var_name="lwp",
         tn=0,
@@ -23,6 +52,10 @@ def test_extract_2d(testdata_path):
         orientation="xy",
         file_prefix="rico",
         source_path=testdata_path,
+        use_cdo=USE_CDO,
+        mode=extraction_mode,
+        dest_path=output_path,
     )
 
     luigi.build([task], local_scheduler=True)
+    assert task.output().exists()

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,22 +1,51 @@
+import os
+import tempfile
+from pathlib import Path
+
 import luigi
+import pytest
 
 import uclales
 
+USE_CDO = os.environ.get("CDO_VERSION", "null") != "null"
+EXTRACTION_MODES = ["blocks", "x_strips", "y_strips"]
 
-def test_extract_3d(testdata_path):
+
+@pytest.mark.parametrize("extraction_mode", EXTRACTION_MODES)
+def test_extract_3d(testdata_path, extraction_mode):
+    if extraction_mode == "blocks" and USE_CDO:
+        # skip this test since we can't currently extract-by-blocks with cdo
+        # and so the extraction will fail
+        return True
+
+    tmpdir = tempfile.TemporaryDirectory()
+    output_path = Path(tmpdir.name)
+
     task = uclales.output.Extract(
         var_name="w",
         tn=0,
         kind="3d",
         file_prefix="rico",
         source_path=testdata_path,
+        use_cdo=USE_CDO,
+        mode=extraction_mode,
+        dest_path=output_path,
     )
 
     luigi.build([task], local_scheduler=True)
     assert task.output().exists()
 
 
-def test_extract_2d(testdata_path):
+@pytest.mark.parametrize("extraction_mode", EXTRACTION_MODES)
+def test_extract_2d(testdata_path, extraction_mode):
+    if extraction_mode == "blocks" and USE_CDO:
+        # skip this test since we can't currently extract-by-blocks with cdo
+        # and so the extraction will fail
+        return True
+
+    tmpdir = tempfile.TemporaryDirectory()
+    output_path = Path(tmpdir.name)
+
     task = uclales.output.Extract(
         var_name="lwp",
         tn=0,
@@ -24,6 +53,9 @@ def test_extract_2d(testdata_path):
         orientation="xy",
         file_prefix="rico",
         source_path=testdata_path,
+        use_cdo=USE_CDO,
+        mode=extraction_mode,
+        dest_path=output_path,
     )
 
     luigi.build([task], local_scheduler=True)

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -13,6 +13,7 @@ def test_extract_3d(testdata_path):
     )
 
     luigi.build([task], local_scheduler=True)
+    assert task.output().exists()
 
 
 def test_extract_2d(testdata_path):
@@ -26,3 +27,4 @@ def test_extract_2d(testdata_path):
     )
 
     luigi.build([task], local_scheduler=True)
+    assert task.output().exists()

--- a/uclales/output/extraction.py
+++ b/uclales/output/extraction.py
@@ -396,8 +396,14 @@ class UCLALESStripSelectVariable(luigi.Task):
                 cdo_command = "gather"
             else:
                 cdo_command = "collgrid"
+
+            # if we're concatenating in the x-direction we need to tell cdo to
+            # add an extra dimension for y
+            if self.dim == "x":
+                cdo_command += ",1"
+
             args = (
-                [f"{cdo_command}"]
+                [cdo_command]
                 + [inp.path for inp in self.input()]
                 + [self.output().path]
             )
@@ -625,8 +631,14 @@ class ExtractByStrips(_Merge3DBaseTask):
                 cdo_command = "gather"
             else:
                 cdo_command = "collgrid"
+
+            # if we're concatenating in the y-direction we need to tell cdo to
+            # add an extra dimension for x
+            if self.dim == "y":
+                cdo_command += ",1"
+
             args = (
-                [f"{cdo_command},1"]
+                [cdo_command]
                 + [inp.path for inp in self.input()["parts"]]
                 + [self.output().path]
             )


### PR DESCRIPTION
Vishnu Nair got in touch with me to let me know that the cdo command `gather` I was using has been renamed in more recent versions of cdo:

> I think gather has been replaced by the command collgrid (and scatter by distgrid). 
When I wrote my own bash scripts, I had been using collgrid as well. Did gather work for you recently? I checked the forums for cdo and found this reply from 2 years ago I think which says that it has been replaced. Should I install a different version of cdo?
https://code.mpimet.mpg.de/boards/53/topics/2342

This pull-request addresses that by checking whether `gather` is available and otherwise uses `collgrid`. The pull-request also adds tests to ensure that this works with different cdo versions