### PR TITLE
Bugfixes and fix testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,26 @@
 # Changelog
 
 
+## [Unreleased](https://github.com/leifdenby/uclales-utils/tree/HEAD)
+
+[Full Changelog](https://github.com/convml/convml_tt/compare/...v0.1.1)
+
+*bugfixes*
+
+- Fix numerous bugs, specifically: 1) ensure `use_cdo` is correctly passed to
+  child-tasks. 2) 3D source-files don't have a timestep (`tn`) in the filename,
+  3) fix concatenation when all extraction is done with xarray, 4) ensure all
+  possible methods of extraction (`blocks`, `x_strips` and `y_strips`) are all
+  tested [\#8](https://github.com/leifdenby/uclales-utils/pull/8)
+
+
 ## [v0.1.1](https://github.com/leifdenby/uclales-utils/tree/v0.1.1) (2022-01-31)
 
 [Full Changelog](https://github.com/convml/convml_tt/compare/v0.1.1...v0.1.0)
 
 *maintance*
 
-Update instructions in the README [\#6](https://github.com/leifdenby/uclales-utils/pull/6)
+- Update instructions in the README [\#6](https://github.com/leifdenby/uclales-utils/pull/6)
 
 
 ## [v0.1.0](https://github.com/leifdenby/uclales-utils/tree/v0.1.0) (2022-01-31)

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,21 +1,50 @@
+import tempfile
+from pathlib import Path
+
 import luigi
+import pytest
 
 import uclales
 
+USE_CDO = False
+EXTRACTION_MODES = ["blocks", "x_strips", "y_strips"]
 
-def test_extract_3d(testdata_path):
+
+@pytest.mark.parametrize("extraction_mode", EXTRACTION_MODES)
+def test_extract_3d(testdata_path, extraction_mode):
+    if extraction_mode == "blocks" and USE_CDO:
+        # skip this test since we can't currently extract-by-blocks with cdo
+        # and so the extraction will fail
+        return True
+
+    tmpdir = tempfile.TemporaryDirectory()
+    output_path = Path(tmpdir.name)
+
     task = uclales.output.Extract(
         var_name="w",
         tn=0,
         kind="3d",
         file_prefix="rico",
         source_path=testdata_path,
+        use_cdo=USE_CDO,
+        mode=extraction_mode,
+        dest_path=output_path,
     )
 
     luigi.build([task], local_scheduler=True)
+    assert task.output().exists()
 
 
-def test_extract_2d(testdata_path):
+@pytest.mark.parametrize("extraction_mode", EXTRACTION_MODES)
+def test_extract_2d(testdata_path, extraction_mode):
+    if extraction_mode == "blocks" and USE_CDO:
+        # skip this test since we can't currently extract-by-blocks with cdo
+        # and so the extraction will fail
+        return True
+
+    tmpdir = tempfile.TemporaryDirectory()
+    output_path = Path(tmpdir.name)
+
     task = uclales.output.Extract(
         var_name="lwp",
         tn=0,
@@ -23,6 +52,10 @@ def test_extract_2d(testdata_path):
         orientation="xy",
         file_prefix="rico",
         source_path=testdata_path,
+        use_cdo=USE_CDO,
+        mode=extraction_mode,
+        dest_path=output_path,
     )
 
     luigi.build([task], local_scheduler=True)
+    assert task.output().exists()


### PR DESCRIPTION
Fix issue for 3D source files which don't need a timestep number (`tn`).
Fix not passing `use_cdo` correctly to child tasks. Fix testing to
ensure that all output is written and luigi tasks has completed
successfully. FIx issue where concatenation wasn't done correctly when using xarray for extraction.