### PR TITLE
Ensure we retain yxz shape for 3D output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
 
+## [Unreleased](https://github.com/leifdenby/uclales-utils/tree/HEAD)
+
+[Full Changelog](https://github.com/convml/convml_tt/compare/HEAD...v0.1.3)
+
+*bugfixes*
+
+- Ensure that coordinate ordering stays the same as in the per-core source
+  files. Previously the ordering was changed to always be (z,y,x)
+  [\#10](https://github.com/leifdenby/uclales-utils/pull/10)
+
+*changed defaults*
+
+- Output files now have same coordinate ordering as source files
+  [\#10](https://github.com/leifdenby/uclales-utils/pull/10), rather than
+  `(z,y,x)` ordering.
+
+- When using `cdo` for extraction, the single variable/timestep extraction is
+  now done also done with `cdo` (rather than `xarray`) for this first step.
+  This ensures that coordinate ordering is unchanged.
+  [\#10](https://github.com/leifdenby/uclales-utils/pull/10), rather than
+
+
 ## [v0.1.3](https://github.com/leifdenby/uclales-utils/tree/v0.1.3)
 
 [Full Changelog](https://github.com/convml/convml_tt/compare/v0.1.3...v0.1.2)

--- a/uclales/output/extraction.py
+++ b/uclales/output/extraction.py
@@ -291,8 +291,8 @@ class UCLALESBlockSelectVariable(luigi.Task):
         else:
             raise NotImplementedError(self.kind)
 
-        # to use cdo the dimensions have to be (time, z, y, x)...
-        posns = dict(time=0, zt=1, zm=1, yt=2, ym=2, xt=3, xm=3)
+        # to use cdo the dimensions have to be (time, y, x, z)...
+        posns = dict(time=0, zt=3, zm=3, yt=1, ym=1, xt=2, xm=2)
         dims = [None, None, None, None]
         for d in list(da_block_var.dims):
             dims[posns[d]] = d

--- a/uclales/output/extraction.py
+++ b/uclales/output/extraction.py
@@ -593,6 +593,7 @@ class ExtractByBlocks(_Merge3DBaseTask):
                     kind=self.kind,
                     orientation=self.orientation,
                     source_path=self.source_path,
+                    use_cdo=self.use_cdo,
                 )
                 tasks_parts.append(t)
 


### PR DESCRIPTION
I'm having some issues with the 3D files generated having the wrong dimension ordering relative to the source column files. So I'm trying to see if I can get this utility to work with cdo having the tracers on `(time, yt, xt, zt)` ordering like the source column files